### PR TITLE
Fix module name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Add `angular-loading.min.js` and `angular-loading.css` to your HTML. Also add [s
 <link rel="stylesheet" type="text/css" href="//rawgithub.com/darthwade/angular-loading/master/angular-loading.css"/>
 ```
 
-Add `darthwade.loading` as a module dependency for your app.
+Add `darthwade.dwLoading` as a module dependency for your app.
 ``` javascript
-angular.module('myApp', ['darthwade.loading']);
+angular.module('myApp', ['darthwade.dwLoading']);
 ```
 
 Add `dw-loading` directive to that block which you want to lock during loading.


### PR DESCRIPTION
The module didn't work for me at first, and I figured out that the name of the module is wrong in the readme.
