### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add `angular-loading.min.js` and `angular-loading.css` to your HTML. Also add [s
 
 Add `darthwade.loading` as a module dependency for your app.
 ``` javascript
-angular.module('myApp', ['darthwade.loading']);
+angular.module('myApp', ['darthwade.dwLoading']);
 ```
 
 Add `dw-loading` directive to that block which you want to lock during loading.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add `angular-loading.min.js` and `angular-loading.css` to your HTML. Also add [s
 <link rel="stylesheet" type="text/css" href="//rawgithub.com/darthwade/angular-loading/master/angular-loading.css"/>
 ```
 
-Add `darthwade.loading` as a module dependency for your app.
+Add `darthwade.dwLoading` as a module dependency for your app.
 ``` javascript
 angular.module('myApp', ['darthwade.dwLoading']);
 ```


### PR DESCRIPTION
in the **usage** paragraph there is a mistake in the module dependency adding.
instead of `darthwade.loading` there should be `darthwade.dwLoading`
It also was in the [issues](https://github.com/darthwade/angular-loading/issues/7) 
