### PR TITLE
removing the element and appending it back in update function

### DIFF
--- a/angular-loading.js
+++ b/angular-loading.js
@@ -147,7 +147,7 @@
                     .text(options.text);
                   body.append(text);
                 }
-                
+                angular.element('.dw-loading').remove();
                 element.append(container);
                 
                 if ( options.active || !key || force) {


### PR DESCRIPTION
append is causing issues when the text attribute is made dynamic with angular binding from controller. Multiple elements of dw-loading class gets added to DOM. So removing the element first and then appending it in update function.